### PR TITLE
[COOK-3178] Move everything to after the ports tree is extracted

### DIFF
--- a/recipes/freebsd.rb
+++ b/recipes/freebsd.rb
@@ -19,14 +19,11 @@
 # limitations under the License.
 #
 
-include_recipe "build-essential"
-include_recipe "git"
-
 # The sed forces portsnap to run non-interactively
 # fetch downloads a ports snapshot, extract puts them on disk (long)
 # update will update an existing ports tree
 portsnap_opts = ::File.exists?("/usr/ports") ? "update" : "fetch extract"
- 
+
 execute "Manage Ports Tree - #{portsnap_opts}" do
   command <<-EOS
     sed -e 's/\\[ ! -t 0 \\]/false/' /usr/sbin/portsnap > /tmp/portsnap
@@ -34,6 +31,9 @@ execute "Manage Ports Tree - #{portsnap_opts}" do
     /tmp/portsnap #{portsnap_opts}
   EOS
 end
+
+include_recipe "build-essential"
+include_recipe "git"
 
 # TODO - move these to build-essential
 %w{
@@ -49,7 +49,7 @@ ruby_block "Disable make parallelization system-wide" do
   block do
     f = Chef::Util::FileEdit.new("/etc/make.conf")
     f.insert_line_if_no_match(/.MAKEFLAGS:/, <<-EOH
- 
+
 .MAKEFLAGS: -B
 EOH
     )


### PR DESCRIPTION
If git is above the ports tree fetch/extract it will fail to install - moving it and build-essential (when it supports freebsd) to below that block
