### PR TITLE
Fix failing Travis CI tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 rvm:
   - 1.9.3
   - 2.0.0
-before_script:
-  - bundle exec berks install
+
 script:
   - bundle exec foodcritic -f any -c 11.6.0 .
   - bundle exec rubocop

--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -20,7 +20,6 @@
 module Omnibus
   # Recipe Helpers
   module Helper
-
     def windows_safe_path_join(*args)
       ::File.join(args).gsub(::File::SEPARATOR, ::File::ALT_SEPARATOR)
     end
@@ -41,7 +40,6 @@ module Omnibus
     #   https://github.com/git/git/commit/4698c8feb1bb56497215e0c10003dd046df352fa
     #
     def with_home_for_user(username, &block)
-
       time = Time.now.to_i
 
       ruby_block "set HOME for #{username} at #{time}" do


### PR DESCRIPTION
- Berkshelf was removed from the Gemfile in: edaeddc318c3f406e0f360b428d4601fac952beb
- Newer Rubocop is a pedant.
