### PR TITLE
Only symlink if bash was built

### DIFF
--- a/recipes/_bash.rb
+++ b/recipes/_bash.rb
@@ -27,7 +27,7 @@ remote_install 'bash' do
   build_command './configure'
   compile_command 'make'
   install_command 'make install'
-  not_if { installed_at_version?('bash', '4.3') }
+  not_if { installed_at_version?('/usr/local/bin/bash', '4.3') }
 end
 
 # Link /bin/bash to our bash, since some systems have their own bash, but we


### PR DESCRIPTION
see: https://github.com/opscode-cookbooks/omnibus/pull/39

Correctly check if we have already installed bash from source
