### PR TITLE
Ensure CPU total is an integer before performing math

### DIFF
--- a/libraries/node.rb
+++ b/libraries/node.rb
@@ -21,6 +21,6 @@ class Chef::Node
   # The number of builders to use for make. By default, this is the total
   # number of CPUs, with a minimum being 2.
   def builders
-    @builders ||= [node['cpu'] && node['cpu']['total'], 2].max
+    @builders ||= [node['cpu'] && node['cpu']['total'].to_i, 2].max
   end
 end


### PR DESCRIPTION
This ensures we don’t get bitten by the bug fixed in: opscode/ohai#421

/cc @opscode-cookbooks/release-engineers 
