### PR TITLE
Disable DTrace integration when compiling Ruby

### DIFF
--- a/libraries/ruby_install.rb
+++ b/libraries/ruby_install.rb
@@ -56,6 +56,7 @@ class Chef
         '--with-out-ext=tk',
         '--without-tcl',
         '--without-tk',
+        '--disable-dtrace',
       ].join(' ')
     end
 


### PR DESCRIPTION
This can cause compilation issues on older Unixes including FreeBSD and 
Solaris.

/cc @opscode-cookbooks/release-engineers @scotthain
