### PR TITLE
Fix infinitely growing Windows PATH

### DIFF
--- a/recipes/_environment.rb
+++ b/recipes/_environment.rb
@@ -29,7 +29,7 @@ if windows?
       REM # Load the base Omnibus environment
       REM ###############################################################
 
-      set PATH=#{omnibus_env['PATH'].join(';')};%PATH%
+      set PATH=#{omnibus_env['PATH'].join(File::PATH_SEPARATOR)};%PATH%
       set SSL_CERT_FILE=#{omnibus_env['SSL_CERT_FILE'].first}
       set HOMEDRIVE=#{ENV['SYSTEMDRIVE']}
       set HOMEPATH=#{build_user_home.split(':').last}

--- a/recipes/_git.rb
+++ b/recipes/_git.rb
@@ -35,7 +35,7 @@ if windows?
   git_paths  = []
   git_paths << windows_safe_path_join(program_files, 'Git', 'Cmd')
   git_paths << windows_safe_path_join(program_files, 'Git', 'libexec', 'git-core')
-  git_path   = git_paths.join(';')
+  git_path   = git_paths.join(File::PATH_SEPARATOR)
 
   omnibus_env['PATH'] << git_path
 else


### PR DESCRIPTION
`PATH` has been disappearing from the system environment on all of our Windows CI slaves. These changes appear to fix the issue.

/cc @opscode-cookbooks/legacy-ci-migration-team
