### PR TITLE
Reintroduce `sign-rpm` script

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,6 +16,9 @@ Documentation:
   Enabled: false
 Encoding:
   Enabled: false
+FileName:
+  Exclude:
+    - files/**/*
 LineLength:
   Enabled: false
 MethodLength:

--- a/files/default/sign-rpm
+++ b/files/default/sign-rpm
@@ -1,0 +1,40 @@
+#!/usr/bin/env ruby
+
+unless (password = ARGV[0]) && (package = ARGV[1])
+  STDERR.puts 'Usage: sign-rpm PASSWORD PACKAGE'
+  exit 1
+end
+
+require 'pty'
+
+rpm_cmd = "rpm --addsign #{package}"
+
+puts rpm_cmd
+PTY.spawn(rpm_cmd) do |r, w, pid|
+  prompt = r.read(19)
+
+  # match the expected prompt exactly, since that's the only way we know if
+  # something went wrong.
+  unless prompt == 'Enter pass phrase: '
+    STDERR.puts "unexpected output from `#{rpm_cmd}`: '#{prompt}'"
+    Process.kill(:KILL, pid)
+    exit 1
+  end
+
+  STDOUT.puts prompt
+  w.write("#{password}\n")
+
+  # Keep printing output unti the command exits
+  loop do
+    begin
+      line = r.gets
+      puts line
+      if line =~ /failed/
+        STDERR.puts 'RPM signing failure'
+        exit 1
+      end
+    rescue Errno::EIO
+      break
+    end
+  end
+end

--- a/recipes/_packaging.rb
+++ b/recipes/_packaging.rb
@@ -39,6 +39,15 @@ when 'rhel'
   package 'ncurses-devel'
   package 'rpm-build'
   package 'zlib-devel'
+
+  # This script makes unattended rpm signing possible!
+  cookbook_file ::File.join(build_user_home, 'sign-rpm') do
+    source 'sign-rpm'
+    mode '0755'
+    owner node['omnibus']['build_user']
+    group node['omnibus']['build_user_group']
+    mode '0755'
+  end
 when 'windows'
   include_recipe '7-zip::default'
   include_recipe 'wix::default'

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -100,4 +100,10 @@ describe 'environment' do
     end
 
   end
+
+  describe file(File.join(home_dir, 'sign-rpm')), if: os[:family] == 'redhat' do
+    it { should be_file }
+    it { should be_owned_by 'omnibus' }
+    it { should be_grouped_into 'omnibus' }
+  end
 end


### PR DESCRIPTION
Although Omnibus 4.0+ ships with an embedded rpm signing script this
cookbook may be used to manage infrastructure that builds pre-4.0
Omnibus projects.

/cc @opscode-cookbooks/release-engineers 
