### PR TITLE
Fix CA bundle location for omnibus env on windows

### DIFF
--- a/recipes/_ruby.rb
+++ b/recipes/_ruby.rb
@@ -51,5 +51,5 @@ if windows?
   ruby_base_path = windows_safe_path_join(ENV['SYSTEMDRIVE'], 'rubies', node['omnibus']['ruby_version'])
   omnibus_env['PATH'] << windows_safe_path_join(ruby_base_path, 'bin')
   omnibus_env['PATH'] << windows_safe_path_join(ruby_base_path, 'mingw', 'bin')
-  omnibus_env['SSL_CERT_FILE'] << windows_safe_path_join(ruby_base_path, 'ssl', 'certs', 'cacerts.pem')
+  omnibus_env['SSL_CERT_FILE'] << windows_safe_path_join(ruby_base_path, 'ssl', 'certs', 'cacert.pem')
 end


### PR DESCRIPTION
The Certificate bundle from curl is saved to cacert.pem not cacerts.oem.
See: https://github.com/opscode-cookbooks/omnibus/blob/master/libraries/ruby_install.rb#L193
