### PR TITLE
Configure BSD Make for backward compat mode

### DIFF
--- a/recipes/_compile.rb
+++ b/recipes/_compile.rb
@@ -34,3 +34,20 @@ include_recipe 'build-essential::default'
 # Use homebrew as the default package manager on OSX. We cannot install homebrew
 # until AFTER we have installed the XCode command line tools via build-essential
 include_recipe 'homebrew::default' if mac_os_x?
+
+if freebsd?
+  # Ensuring BSD Make is executed with the `-B` option (backward-compat mode)
+  # allows many pieces of software to compile without `gmake`. A full
+  # explanation of FreeBSD Make's various options can be found here:
+  #
+  #   https://www.freebsd.org/cgi/man.cgi?query=make(1)&sektion=
+  #
+  ruby_block 'Configure BSD Make for backward compat mode' do
+    block do
+      file = Chef::Util::FileEdit.new('/etc/make.conf')
+      file.insert_line_if_no_match(/\.MAKEFLAGS:/, '.MAKEFLAGS: -B')
+      file.write_file
+    end
+    only_if { File.exist?('/etc/make.conf') }
+  end
+end

--- a/spec/recipes/compile_spec.rb
+++ b/spec/recipes/compile_spec.rb
@@ -13,4 +13,17 @@ describe 'omnibus::_compile' do
                      .converge(described_recipe)
     expect(osx_chef_run).to include_recipe('homebrew::default')
   end
+
+  context 'on freebsd' do
+    let(:chef_run) do
+      ChefSpec::ServerRunner.new(platform: 'freebsd', version: '10.0')
+        .converge(described_recipe)
+    end
+
+    it 'Configures BSD Make for backward compat mode' do
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with('/etc/make.conf').and_return(true)
+      expect(chef_run).to run_ruby_block('Configure BSD Make for backward compat mode')
+    end
+  end
 end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -115,4 +115,9 @@ describe 'environment' do
     it { should be_owned_by 'omnibus' }
     it { should be_grouped_into 'omnibus' }
   end
+
+  describe file('/etc/make.conf'), if: os[:family] == 'freebsd' do
+    it { should be_file }
+    its(:content) { should match(/\.MAKEFLAGS: -B/) }
+  end
 end


### PR DESCRIPTION
Ensuring BSD Make is executed with the `-B` option (backward compat  mode) allows many pieces of software to compile without `gmake`.

/cc @opscode-cookbooks/release-engineers @scotthain @lamont-granquist 
