### PR TITLE
Don’t allow `ruby-install` to install deps

### DIFF
--- a/libraries/ruby_install.rb
+++ b/libraries/ruby_install.rb
@@ -63,7 +63,7 @@ class Chef
     def install
       # Need to compile the command outside of the execute resource because
       # Ruby is bad at instance_eval
-      install_command = "ruby-install ruby #{version} -- #{compile_flags}"
+      install_command = "ruby-install --no-install-deps ruby #{version} -- #{compile_flags}"
 
       execute = Resource::Execute.new("install ruby-#{version}", run_context)
       execute.command(install_command)


### PR DESCRIPTION
We already install all required deps before invoking `ruby-install`!  Allowing `ruby-install` to re-install all these deps can cause issues especially with Homebrew on OS X.

/cc @opscode-cookbooks/release-engineers 
