### PR TITLE
Upgrade Bash to 4.3.30 to fix [CVE-2014-6271] (Shellshock)

### DIFF
--- a/recipes/_bash.rb
+++ b/recipes/_bash.rb
@@ -25,13 +25,13 @@ return if windows?
 include_recipe 'omnibus::_compile'
 
 remote_install 'bash' do
-  source 'http://ftp.gnu.org/gnu/bash/bash-4.3.tar.gz'
-  version '4.3'
-  checksum 'afc687a28e0e24dc21b988fa159ff9dbcf6b7caa92ade8645cc6d5605cd024d4'
+  source 'http://ftp.gnu.org/gnu/bash/bash-4.3.30.tar.gz'
+  version '4.3.30'
+  checksum '317881019bbf2262fb814b7dd8e40632d13c3608d2f237800a8828fbb8a640dd'
   build_command './configure'
   compile_command "make -j #{node.builders}"
   install_command 'make install'
-  not_if { installed_at_version?('/usr/local/bin/bash', '4.3') }
+  not_if { installed_at_version?('/usr/local/bin/bash', '4.3.30') }
 end
 
 # Link /bin/bash to our bash, since some systems have their own bash, but we

--- a/spec/recipes/bash_spec.rb
+++ b/spec/recipes/bash_spec.rb
@@ -11,9 +11,9 @@ describe 'omnibus::_bash' do
     allow_any_instance_of(Chef::Resource).to receive(:installed_at_version?)
 
     expect(chef_run).to install_remote_install('bash')
-      .with_source('http://ftp.gnu.org/gnu/bash/bash-4.3.tar.gz')
-      .with_version('4.3')
-      .with_checksum('afc687a28e0e24dc21b988fa159ff9dbcf6b7caa92ade8645cc6d5605cd024d4')
+      .with_source('http://ftp.gnu.org/gnu/bash/bash-4.3.30.tar.gz')
+      .with_version('4.3.30')
+      .with_checksum('317881019bbf2262fb814b7dd8e40632d13c3608d2f237800a8828fbb8a640dd')
       .with_build_command('./configure')
       .with_compile_command('make -j 2')
       .with_install_command('make install')

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -54,7 +54,7 @@ end
 
 describe 'bash' do
   describe command('/usr/local/bin/bash --version') do
-    its(:stdout) { should match(/4\.3/) }
+    its(:stdout) { should match(/4\.3\.30/) }
   end
 end
 


### PR DESCRIPTION
Fixes #55. Closes #56.

/cc @opscode-cookbooks/release-engineers 
