### PR TITLE
Ensure FreeBSD Ruby install points at valid root CA cert

### DIFF
--- a/recipes/_cacerts.rb
+++ b/recipes/_cacerts.rb
@@ -1,0 +1,46 @@
+#
+# Cookbook Name:: omnibus
+# Recipe:: _cacerts
+#
+# Copyright 2014, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe 'omnibus::_bash'
+
+#
+# On FreeBSD the Ruby install's SSL points at `/etc/ssl/cert.pem` as the
+# default root CA cert. This is actually the location of an optional symlink
+# that the `ca_root_nss` port creates. We can't gurantee this optional
+# symlink will exist so we'll just point `SSL_CERT_FILE` at the actual
+# location of the root CA cert.
+#
+if freebsd?
+  cacert_path = '/usr/local/share/certs/ca-root-nss.crt'
+
+  omnibus_env['SSL_CERT_FILE'] << cacert_path
+
+  file File.join(build_user_home, '.bashrc.d', 'cacerts.sh') do
+    owner   node['omnibus']['build_user']
+    group   node['omnibus']['build_user_group']
+    mode    '0755'
+    content <<-EOH.gsub(/^ {6}/, '')
+      # This file is written by Chef for #{node['fqdn']}.
+      # Do NOT modify this file by hand.
+
+      export SSL_CERT_FILE=#{cacert_path}
+
+    EOH
+  end
+end

--- a/recipes/_environment.rb
+++ b/recipes/_environment.rb
@@ -29,10 +29,10 @@ if windows?
       REM # Load the base Omnibus environment
       REM ###############################################################
 
-      set PATH=#{omnibus_env['PATH'].join(File::PATH_SEPARATOR)};%PATH%
-      set SSL_CERT_FILE=#{omnibus_env['SSL_CERT_FILE'].first}
       set HOMEDRIVE=#{ENV['SYSTEMDRIVE']}
       set HOMEPATH=#{build_user_home.split(':').last}
+      set PATH=#{omnibus_env.delete('PATH').join(File::PATH_SEPARATOR)};%PATH%
+      #{omnibus_env.map { |k, v| "set #{k}=#{v.first}" }.join("\n")}
 
       ECHO(
       ECHO ========================================
@@ -116,6 +116,7 @@ else
       # Load the base Omnibus environment
       ###################################################################
       export PATH="/usr/local/bin:$PATH"
+      #{omnibus_env.map { |k, v| "export #{k}=#{v.first}" }.join("\n")}
 
       # Load chruby
       if ! command -v chruby > /dev/null; then

--- a/recipes/_ruby.rb
+++ b/recipes/_ruby.rb
@@ -22,6 +22,7 @@ include_recipe 'omnibus::_common'
 
 unless windows?
   include_recipe 'omnibus::_bash'
+  include_recipe 'omnibus::_cacerts'
   include_recipe 'omnibus::_chruby'
   include_recipe 'omnibus::_compile'
   include_recipe 'omnibus::_openssl'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,6 +23,7 @@ include_recipe 'omnibus::_common'
 # Include other recipes. Note: they may not be executed in this order, since
 # private recipes may depend on each other.
 include_recipe 'omnibus::_bash'
+include_recipe 'omnibus::_cacerts'
 include_recipe 'omnibus::_ccache'
 include_recipe 'omnibus::_chruby'
 include_recipe 'omnibus::_compile'

--- a/spec/recipes/cacerts_spec.rb
+++ b/spec/recipes/cacerts_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe 'omnibus::_cacerts' do
+  let(:chef_run) { ChefSpec::ServerRunner.converge(described_recipe) }
+
+  it 'includes _bash' do
+    expect(chef_run).to include_recipe('omnibus::_bash')
+  end
+
+  context 'on freebsd' do
+    let(:chef_run) do
+      ChefSpec::ServerRunner.new(platform: 'freebsd', version: '9.1')
+        .converge(described_recipe)
+    end
+
+    it 'creates the .cacerts' do
+      expect(chef_run).to create_file('/home/omnibus/.bashrc.d/cacerts.sh')
+        .with_owner('omnibus')
+        .with_mode('0755')
+    end
+  end
+end

--- a/spec/recipes/ruby_spec.rb
+++ b/spec/recipes/ruby_spec.rb
@@ -17,6 +17,10 @@ describe 'omnibus::_ruby' do
       expect(chef_run).to include_recipe('omnibus::_bash')
     end
 
+    it 'includes _cacerts' do
+      expect(chef_run).to include_recipe('omnibus::_cacerts')
+    end
+
     it 'includes _compile' do
       expect(chef_run).to include_recipe('omnibus::_compile')
     end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -88,6 +88,12 @@ describe 'environment' do
     end
   end
 
+  describe '$SSL_CERT_FILE', if: os[:family] == 'freebsd' do
+    describe command("su - omnibus -l -c 'echo $SSL_CERT_FILE'") do
+      its(:stdout) { should match %r{^/usr/local/share/certs/ca-root-nss.crt} }
+    end
+  end
+
   describe file(File.join(home_dir, 'load-omnibus-toolchain.sh')) do
     it { should be_file }
     # it { should be_owned_by 'omnibus' }


### PR DESCRIPTION
On FreeBSD the Ruby install's SSL points at `/etc/ssl/cert.pem` as the default root CA cert. This is actually the location of an optional symlink that the `ca_root_nss` port creates. We can't guarantee this optional symlink will exist so we'll just point `SSL_CERT_FILE` at the actual location of the root CA cert.

/cc @opscode-cookbooks/release-engineers @sersut 
