### PR TITLE
Create `/etc/ssl/cert.pem` symlink on FreeBSD

### DIFF
--- a/recipes/_cacerts.rb
+++ b/recipes/_cacerts.rb
@@ -43,4 +43,8 @@ if freebsd?
 
     EOH
   end
+
+  link '/etc/ssl/cert.pem' do
+    to '/usr/local/share/certs/ca-root-nss.crt'
+  end
 end

--- a/spec/recipes/cacerts_spec.rb
+++ b/spec/recipes/cacerts_spec.rb
@@ -18,5 +18,10 @@ describe 'omnibus::_cacerts' do
         .with_owner('omnibus')
         .with_mode('0755')
     end
+
+    it 'creates a link from /etc/ssl/cert.pem to /usr/local/share/certs/ca-root-nss.crt' do
+      expect(chef_run).to create_link('/etc/ssl/cert.pem')
+        .with_to('/usr/local/share/certs/ca-root-nss.crt')
+    end
   end
 end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -126,4 +126,8 @@ describe 'environment' do
     it { should be_file }
     its(:content) { should match(/\.MAKEFLAGS: -B/) }
   end
+
+  describe file('/etc/ssl/cert.pem'), if: os[:family] == 'freebsd' do
+    it { should be_symlink }
+  end
 end


### PR DESCRIPTION
This is the default location most Unix tools look for the default root CA cert. The `ca_root_nss` port (which creates `ca-root-nss.crt`) also optionally creates this symlink but we cannot gurantee this was done at port install time.

/cc @opscode-cookbooks/release-engineers 
