### PR TITLE
Use http when downloading fakeroot

### DIFF
--- a/recipes/_fakeroot.rb
+++ b/recipes/_fakeroot.rb
@@ -26,7 +26,7 @@ package 'libcap-devel' # required to build fakeroot
 
 remote_install 'fakeroot' do
   # source code is maintained on debian ftp
-  source 'ftp://ftp.debian.org/debian/pool/main/f/fakeroot/fakeroot_1.20.2.orig.tar.bz2'
+  source 'http://ftp.debian.org/debian/pool/main/f/fakeroot/fakeroot_1.20.2.orig.tar.bz2'
   relative_path 'fakeroot-1.20.2'
   version '1.20.2'
   checksum '7c0a164d19db3efa9e802e0fc7cdfeff70ec6d26cdbdc4338c9c2823c5ea230c'


### PR DESCRIPTION
When converging this cookbook with test-kitchen from behind a web/ftp proxy I couldn't use ftp:// because test-kitchen doesn't support ftp_proxy (yet).

There's some work here for ftp_proxy support: https://github.com/test-kitchen/test-kitchen/pull/414