### PR TITLE
Fix issue with security policy and vagrant 

### DIFF
--- a/recipes/_user.rb
+++ b/recipes/_user.rb
@@ -39,7 +39,7 @@ end
 # On windows alter the security policy to allow poor passwords
 #
 if windows?
-  fix_pw_file = "c:\\users\\vagrant\\fixpwpol.cmd"
+  fix_pw_file = 'c:\users\vagrant\fixpwpol.cmd'
 
   file fix_pw_file do
     action :create
@@ -51,7 +51,7 @@ signature="$CHICAGO$"
 EOC
   end
 
-  execute "FixSecurityPolicy" do
+  execute 'FixSecurityPolicy' do
     command "secedit /configure /db C:\\Windows\\security\\new.sdb /cfg #{fix_pw_file} /areas SECURITYPOLICY"
   end
 end

--- a/recipes/_user.rb
+++ b/recipes/_user.rb
@@ -35,6 +35,27 @@ group node['omnibus']['build_user_group'] do
   ignore_failure true if windows?
 end
 
+#
+# On windows alter the security policy to allow poor passwords
+#
+if windows?
+  fix_pw_file = "c:\\users\\vagrant\\fixpwpol.cmd"
+
+  file fix_pw_file do
+    action :create
+    content <<EOC
+[System Access]\r
+PasswordComplexity = 0\r
+[Version]\r
+signature="$CHICAGO$"
+EOC
+  end
+
+  execute "FixSecurityPolicy" do
+    command "secedit /configure /db C:\\Windows\\security\\new.sdb /cfg #{fix_pw_file} /areas SECURITYPOLICY"
+  end
+end
+
 user node['omnibus']['build_user'] do
   home     build_user_home
   supports manage_home: true


### PR DESCRIPTION
Modern windows machines do not like the weak default password for vagrant; this adds a configuration step to override that policy

This fixes an issue that shows up when using omnibus-chef/kitchen to converge a windows machine.
