### PR TITLE
Use Chef DSL for Ruby install on RHEL and Fedora

### DIFF
--- a/recipes/_ruby.rb
+++ b/recipes/_ruby.rb
@@ -33,7 +33,7 @@ unless windows?
   include_recipe 'omnibus::_yaml'
 
   # The RHEL 7 EC2 images do not include bzip2, which is a dep of ruby-install.
-  package 'bzip2' if rhel?
+  package 'bzip2' if platform_family?('rhel', 'fedora')
 
   # Install ruby-install so we can easily install and manage rubies. This is
   # needed by the +ruby_install+ HWRP which installs rubies for us.


### PR DESCRIPTION
Fedora has the same issue with bzip in a base install. This uses the Chef DSL to check the platform for RHEL and Fedora, rather than copy pasta the same code block for Fedora.

Resolves #115