### PR TITLE
disable password complexity on windows

### DIFF
--- a/recipes/_user.rb
+++ b/recipes/_user.rb
@@ -35,6 +35,16 @@ group node['omnibus']['build_user_group'] do
   ignore_failure true if windows?
 end
 
+if windows?
+  powershell_script 'Disable password complexity requirements' do
+    code <<-EOH
+      secedit /export /cfg $env:temp/export.cfg
+      ((get-content $env:temp/export.cfg) -replace ('PasswordComplexity = 1', 'PasswordComplexity = 0')) | Out-File $env:temp/export.cfg
+      secedit /configure /db $env:windir/security/new.sdb /cfg $env:temp/export.cfg /areas SECURITYPOLICY
+    EOH
+  end
+end
+
 user node['omnibus']['build_user'] do
   home     build_user_home
   supports manage_home: true


### PR DESCRIPTION
I am using a Hyper-V provider vagrant box that already has the vagrant/vagrant username/password set. These were set as part of the unattended setup bypassing password complexity enforcement.  If password complexity has not been disabled on the base box, the recipe will fail.