### PR TITLE
Publish updates to the chef-server.delivery.chef.co

### DIFF
--- a/.delivery/config.json
+++ b/.delivery/config.json
@@ -11,6 +11,7 @@
       }
     },
     "publish": {
+      "chef_server": true,
       "github": "chef-cookbooks/omnibus"
     }
   },

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'releng@chef.io'
 license           'Apache 2.0'
 description       'Prepares a machine to be an Omnibus builder.'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '2.7.0'
+version           '2.7.1'
 
 supports 'amazon'
 supports 'centos'


### PR DESCRIPTION
This will ensure the `omnibus` cookbook is available in URD deployments following the automatic environment pinning updates.

/cc @yzl @oferrigni 