### PR TITLE
delivery-truck should not push to GitHub

### DIFF
--- a/.delivery/config.json
+++ b/.delivery/config.json
@@ -11,8 +11,7 @@
       }
     },
     "publish": {
-      "chef_server": true,
-      "github": "chef-cookbooks/omnibus"
+      "chef_server": true
     }
   },
   "skip_phases": [],


### PR DESCRIPTION
We are already leveraging Delivery’s GitHub integration so no push is needed.
