### PR TITLE
[ES-479] Create a separate OmnibusBuild provider for Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ omnibus Cookbook CHANGELOG
 ==========================
 This file is used to list changes made in each version of the omnibus cookbook.
 
+v2.7.4
+------
+- Create a separate Windows-specific OmnibusBuild provider
+
 v2.7.3 (2015-10-08)
 --------------------
 - Added Windows support to the `omnibus_build` resource

--- a/libraries/ruby_install.rb
+++ b/libraries/ruby_install.rb
@@ -215,6 +215,7 @@ class Chef
       cacerts.source('cacert.pem')
       cacerts.cookbook('omnibus')
       cacerts.backup(false)
+      cacerts.sensitive(true)
       cacerts.run_action(:create)
     end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'releng@chef.io'
 license           'Apache 2.0'
 description       'Prepares a machine to be an Omnibus builder.'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '2.7.3'
+version           '2.7.4'
 
 supports 'amazon'
 supports 'centos'

--- a/recipes/_git.rb
+++ b/recipes/_git.rb
@@ -87,6 +87,10 @@ elsif windows?
   git_paths << windows_safe_path_join(program_files, 'Git', 'libexec', 'git-core')
   git_path = git_paths.join(File::PATH_SEPARATOR)
 
+  windows_path git_path do
+    action :add
+  end
+
   omnibus_env['PATH'] << git_path
 else
   include_recipe 'omnibus::_bash'

--- a/spec/libraries/provider_omnibus_build_spec.rb
+++ b/spec/libraries/provider_omnibus_build_spec.rb
@@ -17,55 +17,6 @@
 require 'chef'
 require 'spec_helper'
 
-describe Chef::Resource::OmnibusBuild do
-  subject { Chef::Resource::OmnibusBuild.new(project_name, run_context) }
-  let(:node) { stub_node(platform: 'ubuntu', version: '12.04') }
-  let(:run_context) { Chef::RunContext.new(node, {}, nil) }
-  let(:build_user) { 'morty' }
-  let(:project_dir) { "/home/#{build_user}/#{project_name}" }
-  let(:project_name) { 'meeseeks' }
-
-  it 'has a default omnibus_base_dir' do
-    expect(subject.omnibus_base_dir).to eq('/var/cache/omnibus')
-  end
-
-  it 'has a default install_dir based on the project name' do
-    expect(subject.install_dir).to eq("/opt/#{project_name}")
-  end
-
-  it 'has a default config_file based on the project_dir' do
-    subject.project_dir(project_dir)
-    expect(subject.config_file).to eq(File.join(project_dir, 'omnibus.rb'))
-  end
-
-  it 'has a default build_user based on node attributes' do
-    node.set['omnibus']['build_user'] = build_user
-    expect(subject.build_user).to eq(build_user)
-  end
-
-  context 'on Windows' do
-    let(:project_dir) { "C:/Users/#{build_user}/#{project_name}" }
-
-    before do
-      allow(ENV).to receive(:[]).with('SYSTEMDRIVE').and_return('C:')
-      allow(ChefConfig).to receive(:windows?).and_return(true)
-    end
-
-    it 'has a Windowsy default omnibus_base_dir' do
-      expect(subject.omnibus_base_dir).to eq('C:/omnibus-ruby')
-    end
-
-    it 'has a Windowsy default install_dir based on the project name' do
-      expect(subject.install_dir).to eq("C:/#{project_name}")
-    end
-
-    it 'has a Windowsy default config_file based on the project_dir' do
-      subject.project_dir(project_dir)
-      expect(subject.config_file).to eq(File.join(project_dir, 'omnibus.rb'))
-    end
-  end
-end
-
 describe Chef::Provider::OmnibusBuild do
   subject { Chef::Provider::OmnibusBuild.new(resource, run_context) }
 
@@ -198,7 +149,8 @@ describe Chef::Provider::OmnibusBuild do
     it 'loads the omnbius toolchain from the build user home' do
       expect(execute_resource).to receive(:command).with(
         <<-EOH.gsub(/^ {10}/, '')
-          source #{build_user_home}\/load-omnibus-toolchain.sh && #{command}
+          source #{build_user_home}\/load-omnibus-toolchain.sh
+          #{command}
         EOH
       )
       subject.send(:execute_with_omnibus_toolchain, command)
@@ -217,24 +169,6 @@ describe Chef::Provider::OmnibusBuild do
     it 'executes the command as the provided user' do
       expect(execute_resource).to receive(:user).with(build_user)
       subject.send(:execute_with_omnibus_toolchain, command)
-    end
-
-    context 'on Windows' do
-      let(:node) { stub_node(platform: 'windows', version: '2012R2') }
-
-      it 'loads the omnbius toolchain from the build user home' do
-        expect(execute_resource).to receive(:command).with(
-          <<-EOH.gsub(/^ {12}/, '')
-            call #{build_user_home}\/load-omnibus-toolchain.bat && #{command}
-          EOH
-        )
-        subject.send(:execute_with_omnibus_toolchain, command)
-      end
-
-      it 'does not provide a user' do
-        expect(execute_resource).to_not receive(:user).with(build_user)
-        subject.send(:execute_with_omnibus_toolchain, command)
-      end
     end
   end
 end

--- a/spec/libraries/provider_omnibus_build_windows_spec.rb
+++ b/spec/libraries/provider_omnibus_build_windows_spec.rb
@@ -1,0 +1,65 @@
+#
+# Copyright 2015, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef'
+require 'spec_helper'
+
+describe Chef::Provider::OmnibusBuildWindows do
+  subject { Chef::Provider::OmnibusBuildWindows.new(resource, run_context) }
+
+  let(:build_user) { 'some_user' }
+  let(:build_user_home) { "C:/Users/#{build_user}" }
+  let(:project_dir) { 'C:/build/harmony' }
+
+  let(:node) { stub_node(platform: 'windows', version: '2012R2') }
+
+  let(:run_context) { Chef::RunContext.new(node, {}, nil) }
+  let(:resource) do
+    r = Chef::Resource::OmnibusBuild.new('harmony', run_context)
+    r.project_dir(project_dir)
+    r.build_user(build_user)
+    r
+  end
+
+  before do
+    allow(subject).to receive(:build_user_home).and_return(build_user_home)
+  end
+
+  describe '#execute_with_omnibus_toolchain' do
+    let(:command) { 'ruby --version' }
+    let(:execute_resource) do
+      double(
+        Chef::Resource::Execute, command: nil,
+                                 cwd: nil,
+                                 environment: nil,
+                                 run_action: nil,
+                                 user: nil,
+                                 group: nil
+      )
+    end
+
+    before do
+      allow(Chef::Resource::Execute).to receive(:new).and_return(execute_resource)
+    end
+
+    it 'loads the omnbius toolchain from the build user home' do
+      expect(execute_resource).to receive(:command).with(
+        "call #{build_user_home}\/load-omnibus-toolchain.bat && #{command}"
+      )
+      subject.send(:execute_with_omnibus_toolchain, command)
+    end
+  end
+end

--- a/spec/libraries/resource_omnibus_build_spec.rb
+++ b/spec/libraries/resource_omnibus_build_spec.rb
@@ -1,0 +1,67 @@
+#
+# Copyright 2015, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef'
+require 'spec_helper'
+
+describe Chef::Resource::OmnibusBuild do
+  subject { Chef::Resource::OmnibusBuild.new(project_name, run_context) }
+  let(:node) { stub_node(platform: 'ubuntu', version: '12.04') }
+  let(:run_context) { Chef::RunContext.new(node, {}, nil) }
+  let(:build_user) { 'morty' }
+  let(:project_dir) { "/home/#{build_user}/#{project_name}" }
+  let(:project_name) { 'meeseeks' }
+
+  it 'has a default omnibus_base_dir' do
+    expect(subject.omnibus_base_dir).to eq('/var/cache/omnibus')
+  end
+
+  it 'has a default install_dir based on the project name' do
+    expect(subject.install_dir).to eq("/opt/#{project_name}")
+  end
+
+  it 'has a default config_file based on the project_dir' do
+    subject.project_dir(project_dir)
+    expect(subject.config_file).to eq(File.join(project_dir, 'omnibus.rb'))
+  end
+
+  it 'has a default build_user based on node attributes' do
+    node.set['omnibus']['build_user'] = build_user
+    expect(subject.build_user).to eq(build_user)
+  end
+
+  context 'on Windows' do
+    let(:project_dir) { "C:/Users/#{build_user}/#{project_name}" }
+
+    before do
+      allow(ENV).to receive(:[]).with('SYSTEMDRIVE').and_return('C:')
+      allow(ChefConfig).to receive(:windows?).and_return(true)
+    end
+
+    it 'has a Windowsy default omnibus_base_dir' do
+      expect(subject.omnibus_base_dir).to eq('C:/omnibus-ruby')
+    end
+
+    it 'has a Windowsy default install_dir based on the project name' do
+      expect(subject.install_dir).to eq("C:/#{project_name}")
+    end
+
+    it 'has a Windowsy default config_file based on the project_dir' do
+      subject.project_dir(project_dir)
+      expect(subject.config_file).to eq(File.join(project_dir, 'omnibus.rb'))
+    end
+  end
+end


### PR DESCRIPTION
Builds on changes introduced in #130. This removes gnarly branching logic for the Windows case. It also allows a multi-line command on *nix so the sourcing of the `load-omnibus-toolchain.sh` works as expected.

/cc @oferrigni @yzl @xenolinguist