### PR TITLE
Fix Windows detection on older Chef versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ omnibus Cookbook CHANGELOG
 ==========================
 This file is used to list changes made in each version of the omnibus cookbook.
 
+v2.7.7
+------
+- Fix Windows detection on older Chef versions
+
 v2.7.6
 ------
 - Bump the version pin on the wix cookbook.  We now depend on Wix 3.10 features.

--- a/libraries/omnibus_build.rb
+++ b/libraries/omnibus_build.rb
@@ -33,10 +33,10 @@ class Chef
               required: true
     attribute :install_dir,
               kind_of: String,
-              default: lazy { |r| ChefConfig.windows? ? ::File.join(ENV['SYSTEMDRIVE'], r.project_name) : "/opt/#{r.project_name}" }
+              default: lazy { |r| Chef::Platform.windows? ? ::File.join(ENV['SYSTEMDRIVE'], r.project_name) : "/opt/#{r.project_name}" }
     attribute :omnibus_base_dir,
               kind_of: String,
-              default: lazy { ChefConfig.windows? ? ::File.join(ENV['SYSTEMDRIVE'], 'omnibus-ruby') : '/var/cache/omnibus' }
+              default: lazy { Chef::Platform.windows? ? ::File.join(ENV['SYSTEMDRIVE'], 'omnibus-ruby') : '/var/cache/omnibus' }
     attribute :log_level,
               kind_of: Symbol,
               equal_to: [:internal, :debug, :info, :warn, :error, :fatal],

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'releng@chef.io'
 license           'Apache 2.0'
 description       'Prepares a machine to be an Omnibus builder.'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '2.7.6'
+version           '2.7.7'
 
 supports 'amazon'
 supports 'centos'


### PR DESCRIPTION
The `ChefConfig` class is only available on recent versions of Chef.

/cc @chef-cookbooks/delivery-migration-team 