### PR TITLE
Properly detect if the Toolchain is installed at a particular version

### DIFF
--- a/recipes/_omnibus_toolchain.rb
+++ b/recipes/_omnibus_toolchain.rb
@@ -21,8 +21,10 @@
 toolchain_name = node['omnibus']['toolchain_name']
 toolchain_version = node['omnibus']['toolchain_version']
 
-if File.exist?('/opt/omnibus-toolchain') || File.exist?('/opt/angry-omnibus-toolchain')
-  Chef::Log.warn('Assuming the existence of /opt/(angry-)omnibus-toolchain means that the package is already installed.')
+if File.exist?("/opt/#{toolchain_name}/version-manifest.json") &&
+   (JSON.parse(File.read("/opt/#{toolchain_name}/version-manifest.json"))['build_version'] == toolchain_version)
+
+  Chef::Log.info("`#{toolchain_name}` is already installed at version #{toolchain_version}.")
 else
   install_options = ''
   if solaris_10?


### PR DESCRIPTION
This fixes the case where `omnibus-toolchain` will not install on a builder that has built `angry-omnibus-toolchain` one time. It also allows us to support upgrade scenarios.

/cc @chef-cookbooks/engineering-services 
