### PR TITLE
Allow omnibus_build resource to not specify config_overrides

### DIFF
--- a/libraries/omnibus_build.rb
+++ b/libraries/omnibus_build.rb
@@ -94,7 +94,7 @@ class Chef
         new_resource.project_name,
         "--log-level #{new_resource.log_level}",
         "--config #{new_resource.config_file}",
-        "--override #{new_resource.config_overrides.map { |k, v| "#{k}:#{v}" }.join(' ')}"
+        new_resource.config_overrides.empty? ? '' : "--override #{new_resource.config_overrides.map { |k, v| "#{k}:#{v}" }.join(' ')}"
       ].join(' ')
     end
 

--- a/spec/libraries/provider_omnibus_build_spec.rb
+++ b/spec/libraries/provider_omnibus_build_spec.rb
@@ -83,6 +83,10 @@ describe Chef::Provider::OmnibusBuild do
       expect(subject.send(:build_command)).to match(/--log-level internal/)
     end
 
+    it 'does not have an override CLI option' do
+      expect(subject.send(:build_command)).to_not match(/--override/)
+    end
+
     context 'config overrides are set' do
       let(:config_overrides) do
         {


### PR DESCRIPTION
If you don't have any config_overrides like this:
```ruby
omnibus_build 'foo' do
  project_dir '/home/vagrant/foo'
end
```

Will create a command line like this:
```
bundle exec omnibus build foo --log-level internal --config /home/vagrant/foo/omnibus.rb --override
```

Which isn't valid and results in nothing being built. My changes fix that by leaving off the `--override` option if there aren't any overrides.