### PR TITLE
Setup windows builders to build ruby

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -21,7 +21,7 @@ supports 'ubuntu'
 supports 'windows'
 
 depends '7-zip'
-depends 'build-essential'
+depends 'build-essential', '>= 2.3.0'
 depends 'chef-sugar', '>= 3.2.0'
 depends 'git'
 depends 'homebrew'

--- a/recipes/_compile.rb
+++ b/recipes/_compile.rb
@@ -20,8 +20,6 @@
 # Include the common recipe
 include_recipe 'omnibus::_common'
 
-return if windows?
-
 #
 # This recipe is used to install additional packages/utilities that are not
 # included by default in the build-essential cookbook. In the long term, this
@@ -81,4 +79,8 @@ elsif rhel?
   #   https://github.com/CentOS/sig-cloud-instance-images/issues/4
   #
   package 'tar'
+elsif windows?
+  msys_path = windows_safe_path_expand(node['build-essential']['msys']['path'])
+  omnibus_env['PATH'] << msys_path
+  omnibus_env['PATH'] << windows_safe_path_join(msys_path, 'mingw', 'bin')
 end

--- a/recipes/_compile.rb
+++ b/recipes/_compile.rb
@@ -80,7 +80,7 @@ elsif rhel?
   #
   package 'tar'
 elsif windows?
-  msys_path = windows_safe_path_expand(node['build-essential']['msys']['path'])
-  omnibus_env['PATH'] << msys_path
+  msys_path = node['build-essential']['msys']['path']
+  omnibus_env['PATH'] << windows_safe_path_join(msys_path, 'bin')
   omnibus_env['PATH'] << windows_safe_path_join(msys_path, 'mingw', 'bin')
 end

--- a/recipes/_ruby.rb
+++ b/recipes/_ruby.rb
@@ -27,7 +27,6 @@ r = ruby_install node['omnibus']['ruby_version']
 
 if windows?
   omnibus_env['PATH'] << windows_safe_path_join(r.prefix, 'bin')
-  omnibus_env['PATH'] << windows_safe_path_join(r.prefix, 'mingw', 'bin')
   omnibus_env['SSL_CERT_FILE'] << windows_safe_path_join(r.prefix, 'ssl', 'certs', 'cacert.pem')
 else
   omnibus_env['PATH'] << ::File.join(r.prefix, 'bin')


### PR DESCRIPTION
There's 2 changes here:

First, we need to get the build toolchain into the path. These changes are in `_compile.rb`.
Second, I've removed the devkit mingw from the path because:

> Devkit installs a thing which does this. It runs that whenever
> rubygems needs to gem install something that has native extensions.
> 
> The issue with having this in the path is if you did something like
> install a build toolchain that came before the devkit mingw path.
> In this case, gem installing will not correctly use the devkit toolchain
> because it only checks that Devkit/mingw is in the path, meaning the
> toolchain we put in front of it will be used instead.

This relies on https://github.com/chef-cookbooks/build-essential/pull/80 to function correctly