### PR TITLE
Work with test-kitchen and bento boxes

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,6 +7,8 @@ driver:
 provisioner:
   name: chef_zero
   require_chef_omnibus: <%= ENV['CHEF_VERSION'] || '12.5.1' %>
+  attributes:
+    vagrant: true
 
 platforms:
   - name: centos-5.11
@@ -54,6 +56,9 @@ platforms:
   - name: macosx-10.11
     driver:
       box: chef/macosx-10.11 # private
+  - name: windows-server-2008r2-standard
+    driver:
+      box: chef/windows-server-2008r2-standard # private
   - name: windows-server-2012r2-standard
     driver:
       box: chef/windows-server-2012r2-standard # private

--- a/metadata.rb
+++ b/metadata.rb
@@ -20,7 +20,6 @@ supports 'suse'
 supports 'ubuntu'
 supports 'windows'
 
-depends '7-zip'
 depends 'build-essential', '>= 2.3.0'
 depends 'chef-sugar', '>= 3.2.0'
 depends 'git'

--- a/recipes/_common.rb
+++ b/recipes/_common.rb
@@ -21,6 +21,14 @@
 include_recipe 'chef-sugar::default'
 require 'chef/sugar/core_extensions'
 
+# This works around the fact that 7-zip's default differs from the default installer:
+# *we* tell it where to put it. 7-zip is installed by build-essentials, which is
+# called from _compile. We do it at the top because many things include 7zip and we
+# want to be triple sure.
+if windows?
+  node.default['7-zip']['home'] = windows_safe_path_join(ENV['SYSTEMDRIVE'], 'Program Files', '7-zip')
+end
+
 # Create the user
 include_recipe 'omnibus::_user'
 

--- a/recipes/_compile.rb
+++ b/recipes/_compile.rb
@@ -26,7 +26,6 @@ include_recipe 'omnibus::_common'
 # recipe should just "go away" and the build-essential cookbook should become
 # more awesome.
 #
-
 include_recipe 'build-essential::default'
 
 if freebsd?

--- a/recipes/_packaging.rb
+++ b/recipes/_packaging.rb
@@ -61,13 +61,10 @@ elsif rhel?
     mode '0755'
   end
 elsif windows?
-  include_recipe '7-zip::default'
   include_recipe 'wix::default'
   include_recipe 'windows-sdk::windows_sdk'
 
   omnibus_env['PATH'] << node['wix']['home']
   omnibus_env['PATH'] << node['7-zip']['home']
-  # This works around 7-zip apparently not respecting its install dir, and installing to Program Files instead.
-  omnibus_env['PATH'] << windows_safe_path_join(ENV['SYSTEMDRIVE'], 'Program Files', '7-zip')
   omnibus_env['PATH'] << windows_safe_path_join(ENV['ProgramFiles(x86)'] || ENV['ProgramFiles'], 'Windows Kits', '8.1', 'bin', 'x64')
 end

--- a/recipes/_user.rb
+++ b/recipes/_user.rb
@@ -23,6 +23,17 @@ include_recipe 'omnibus::_common'
 # Install the omnibus toolchain so we have a shell
 include_recipe 'omnibus::_omnibus_toolchain'
 
+# If this is an ephemeral vagrant/test-kitchen instance, we relax the password
+# so that the default password "vagrant" can be used.
+powershell_script 'Disable password complexity requirements' do
+  only_if { windows? && vagrant? }
+  code <<-EOH
+    secedit /export /cfg $env:temp/export.cfg
+    ((get-content $env:temp/export.cfg) -replace ('PasswordComplexity = 1', 'PasswordComplexity = 0')) | Out-File $env:temp/export.cfg
+    secedit /configure /db $env:windir/security/new.sdb /cfg $env:temp/export.cfg /areas SECURITYPOLICY
+  EOH
+end
+
 # If this is a fresh solaris 10 system, there will not be an /export/home
 # directory, and useradd doesn't do recursive create with -m
 directory '/export/home' do


### PR DESCRIPTION
This allows users to run `omnibus::ephemeral` to set up an ephemeral slave whose security they don't care about, without compromising the default recipe, so that test-kitchen runs are easier to do in vagrant (whose password does not pass the default password requirements in a bento box).