### PR TITLE
Workaround Curl bug in the Debian 8 Docker image

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -5,6 +5,11 @@ platforms:
   - name: debian-7
     run_list: apt::default
   - name: debian-8
+    driver:
+      provision_command:
+        # Ensure wget is installed to workaround:
+        #   https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=814070
+        - apt-get install -y wget
     run_list: apt::default
   - name: ubuntu-12.04
     run_list: apt::default


### PR DESCRIPTION
There is a bug in the version of Curl (7.38.0) that ships in the Debian 8 Docker image. This version of Curl returns the following error when attempting to download a Chef package from **packages.chef.io**:

```
curl: (60) SSL certificate problem: unable to get local issuer certificate
```

This does not appear to be an SNI issue as the **chef.bintray.com** version Chef package URL returns the same error. Furthermore Wget downloads the Chef package without issue. Full details on the Curl bug at:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=814070

The easiest workaround is to ensure Wget is installed before attempting to install Chef as `install.sh` will use `curl` or `wget` to fetch remote files:
https://git.io/vVO4r

/cc @chef-cookbooks/engineering-services 