### PR TITLE
The `source` command is not available in all shells

### DIFF
--- a/libraries/omnibus_build.rb
+++ b/libraries/omnibus_build.rb
@@ -133,7 +133,7 @@ class Chef
       execute = Resource::Execute.new("#{new_resource.project_name}: #{command}", run_context)
       execute.command(
         <<-CODE.gsub(/^ {10}/, '')
-          source #{::File.join(build_user_home, 'load-omnibus-toolchain.sh')}
+          . #{::File.join(build_user_home, 'load-omnibus-toolchain.sh')}
           #{command}
         CODE
       )

--- a/spec/libraries/provider_omnibus_build_spec.rb
+++ b/spec/libraries/provider_omnibus_build_spec.rb
@@ -157,7 +157,7 @@ describe Chef::Provider::OmnibusBuild do
     it 'loads the omnbius toolchain from the build user home' do
       expect(execute_resource).to receive(:command).with(
         <<-EOH.gsub(/^ {10}/, '')
-          source #{build_user_home}\/load-omnibus-toolchain.sh
+          . #{build_user_home}\/load-omnibus-toolchain.sh
           #{command}
         EOH
       )


### PR DESCRIPTION
The backward compatible way to source `load-omnibus-toolchain.sh` is using `.` which is available in `/bin/sh`.

Fixes #141
