### PR TITLE
Support true 32-bit Windows build toolchain

### DIFF
--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -58,6 +58,10 @@ module Omnibus
         '/usr/local/bin/bash'
       end
     end
+
+    def windows_arch_i386?
+      windows? && (i386? || (node.name =~ /i386/))
+    end
   end
 end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -20,7 +20,7 @@ supports 'suse'
 supports 'ubuntu'
 supports 'windows'
 
-depends 'build-essential', '>= 3.0.0'
+depends 'build-essential', '>= 4.0.0'
 depends 'chef-sugar', '>= 3.2.0'
 depends 'chef-ingredient', '>= 0.18.0'
 depends 'git'

--- a/recipes/_compile.rb
+++ b/recipes/_compile.rb
@@ -80,7 +80,12 @@ elsif rhel?
   package 'tar'
   package 'bzip2'
 elsif windows?
-  msys_path = node['build-essential']['msys']['path']
-  omnibus_env['PATH'] << windows_safe_path_join(msys_path, 'bin')
-  omnibus_env['PATH'] << windows_safe_path_join(msys_path, 'mingw', 'bin')
+  mingw_path = if windows_arch_i386?
+                 node['build-essential']['mingw32']['path']
+               else
+                 node['build-essential']['mingw64']['path']
+               end
+
+  omnibus_env['PATH'] << windows_safe_path_join(mingw_path, 'bin')
+  omnibus_env['PATH'] << windows_safe_path_join(mingw_path, 'msys', '1.0', 'bin')
 end

--- a/spec/libraries/provider_omnibus_build_windows_spec.rb
+++ b/spec/libraries/provider_omnibus_build_windows_spec.rb
@@ -21,8 +21,8 @@ describe Chef::Provider::OmnibusBuildWindows do
   subject { Chef::Provider::OmnibusBuildWindows.new(resource, run_context) }
 
   let(:build_user) { 'some_user' }
-  let(:build_user_home) { "C:/Users/#{build_user}" }
-  let(:project_dir) { 'C:/build/harmony' }
+  let(:build_user_home) { "C:\\Users\\#{build_user}" }
+  let(:project_dir) { 'C:\build\harmony' }
 
   let(:node) { stub_node(platform: 'windows', version: '2012R2') }
 
@@ -57,7 +57,7 @@ describe Chef::Provider::OmnibusBuildWindows do
 
     it 'loads the omnbius toolchain from the build user home' do
       expect(execute_resource).to receive(:command).with(
-        "call #{build_user_home}\/load-omnibus-toolchain.bat && #{command}"
+        "call #{build_user_home}\\load-omnibus-toolchain.bat && #{command}"
       )
       subject.send(:execute_with_omnibus_toolchain, command)
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,11 @@ RSpec.configure do |config|
     # changes. Global state is hard...
     allow_any_instance_of(Chef::Recipe).to receive(:build_user_home)
       .and_return('/home/omnibus')
+
+    # Allow us to mimic a Windows node
+    stub_const('File::ALT_SEPARATOR', '\\')
+    allow(ENV).to receive(:[])
+    allow(ENV).to receive(:[]).with('SYSTEMDRIVE').and_return('C:')
   end
 
   config.log_level = :fatal


### PR DESCRIPTION
The `build-essential` cookbook now installs both a 32-bit and 64-bit compile MinGW toolchain on Windows by default: https://github.com/chef-cookbooks/build-essential/pull/106 This PR updates `load-omnibus-toolchain.bat` to prefer the 32-bit toolchain on nodes that are identified as 32-bit.

/cc @chef-cookbooks/engineering-services @ksubrama @tyler-ball 
