### PR TITLE
update build-essential msys path attribute keys to work with latest build-essentials cookbook

### DIFF
--- a/recipes/_compile.rb
+++ b/recipes/_compile.rb
@@ -80,7 +80,7 @@ elsif rhel?
   package 'tar'
   package 'bzip2'
 elsif windows?
-  msys_path = node['build-essential']['msys']['path']
+  msys_path = node['build-essential']['mingw64']['path']
   omnibus_env['PATH'] << windows_safe_path_join(msys_path, 'bin')
   omnibus_env['PATH'] << windows_safe_path_join(msys_path, 'mingw', 'bin')
 end


### PR DESCRIPTION
Changes to the build-essentials cookbook [here](https://github.com/chef-cookbooks/build-essential/commit/f671cf837e1e5493aa71dac6eee1a36597c103a1) broke this cookbook on windows. The build-essentials cookbook now defines paths for both 64 and 32 bit msys.

To get unblocked I just use the 64bit path here but I'm unsure that is the correct course of action. It seems wrong to add both since one will override the other. Maybe it needs to be dynamically added at some point in the build.

Thoughts @ksubrama ?