### PR TITLE
default to ruby version 2.1.8

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,7 +22,7 @@ default['omnibus'].tap do |omnibus|
   omnibus['toolchain_name']     = 'omnibus-toolchain'
   omnibus['toolchain_version']  = '1.1.6'
   omnibus['git_version']        = '2.6.2'
-  omnibus['ruby_version']       = '2.1.5'
+  omnibus['ruby_version']       = '2.1.8'
 
   if platform_family == 'windows'
     omnibus['build_user_group'] = 'Administrators'


### PR DESCRIPTION
This should fix licensing download errors on jenkins chef builders. On ruby 2.1.5 (the current ruby default version) the following code:
```
require 'open-uri'
open("https://www.openssl.org/source/license.html")
```
produces an error:
```
OpenSSL::SSL::SSLError: SSL_connect SYSCALL returned=5 errno=0 state=SSLv2/v3 read server hello A
```
Ruby 2.1.8 is able to successfully download the license.