### PR TITLE
Bump the version of omnibus-toolchain to 1.1.7

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,7 +20,7 @@ default['omnibus'].tap do |omnibus|
   omnibus['build_user_home']    = nil
   omnibus['install_dir']        = nil
   omnibus['toolchain_name']     = 'omnibus-toolchain'
-  omnibus['toolchain_version']  = '1.1.6'
+  omnibus['toolchain_version']  = '1.1.7'
   omnibus['git_version']        = '2.6.2'
   omnibus['ruby_version']       = '2.1.5'
 


### PR DESCRIPTION
/cc: @chef-cookbooks/engineering-services 

This is preparing to get Ruby 2.1.8 that is included in omnibus-toolchain 1.1.7 into our slaves.