### PR TITLE
Enable the EPEL repo on CentOS to install fakeroot

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -30,6 +30,7 @@ depends 'remote_install'
 depends 'windows'
 depends 'wix'
 depends 'windows-sdk'
+depends 'yum'
 
 source_url 'https://github.com/chef-cookbooks/omnibus' if respond_to?(:source_url)
 issues_url 'https://github.com/chef-cookbooks/omnibus/issues' if respond_to?(:issues_url)

--- a/recipes/_fakeroot_package.rb
+++ b/recipes/_fakeroot_package.rb
@@ -1,0 +1,38 @@
+#
+# Cookbook Name:: omnibus
+# Recipe:: _fakeroot_package
+#
+# Copyright 2016, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+platform_version =
+  if node['platform_version'].satisfies?('~> 7')
+    7
+  elsif node['platform_version'].satisfies?('~> 6')
+    6
+  else
+    8
+  end
+
+# add the EPEL repo for fakeroot if we're on centos
+yum_repository 'epel' do
+  description 'Extra Packages for Enterprise Linux'
+  mirrorlist "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-#{platform_version}&arch=$basearch"
+  gpgkey "http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-#{platform_version}"
+  only_if { centos? }
+  action :create
+end
+
+package 'fakeroot'

--- a/recipes/_fakeroot_source.rb
+++ b/recipes/_fakeroot_source.rb
@@ -1,8 +1,8 @@
 #
 # Cookbook Name:: omnibus
-# Recipe:: _fakeroot
+# Recipe:: _fakeroot_source
 #
-# Copyright 2015, Chef Software, Inc.
+# Copyright 2016, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/_packaging.rb
+++ b/recipes/_packaging.rb
@@ -34,9 +34,9 @@ elsif freebsd?
   package 'devel/ncurses'
 elsif rhel?
   if node['platform_version'].satisfies?('>= 7') && (ppc64? || ppc64le?)
-    include_recipe 'omnibus::_fakeroot'
+    include_recipe 'omnibus::_fakeroot_source'
   else
-    package 'fakeroot'
+    include_recipe 'omnibus::_fakeroot_package'
   end
   package 'ncurses-devel'
   package 'rpm-build'

--- a/spec/recipes/fakeroot_package_spec.rb
+++ b/spec/recipes/fakeroot_package_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe 'omnibus::_fakeroot_package' do
+  context 'on rhel' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'redhat', version: '6.5')
+                          .converge(described_recipe)
+    end
+
+    it 'does not enable EPEL' do
+      expect(chef_run).to_not create_yum_repository('epel')
+    end
+
+    it 'installs fakeroot' do
+      expect(chef_run).to install_package('fakeroot')
+    end
+  end
+
+  context 'on centos' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: '6.5')
+                          .converge(described_recipe)
+    end
+
+    it 'enables the EPEL repo' do
+      expect(chef_run).to create_yum_repository('epel')
+    end
+
+    it 'installs fakeroot' do
+      expect(chef_run).to install_package('fakeroot')
+    end
+  end
+end

--- a/spec/recipes/packaging_spec.rb
+++ b/spec/recipes/packaging_spec.rb
@@ -41,4 +41,39 @@ describe 'omnibus::_packaging' do
       expect(chef_run).to install_package('zlib-devel')
     end
   end
+
+  context "on centos" do
+    shared_examples "installs from package repos" do
+      let(:chef_run) do
+        ChefSpec::SoloRunner.new(platform: 'centos', version: centos_version)
+                            .converge(described_recipe)
+      end
+
+      it "installs from the package repos" do
+        expect(chef_run).to include_recipe("omnibus::_fakeroot_package")
+      end
+    end
+
+    context "on centos 6" do
+      let(:centos_version) { '6.6' }
+      it_behaves_like "installs from package repos"
+    end
+
+    context "on centos 7" do
+      let(:centos_version) { '7.0' }
+      it_behaves_like "installs from package repos"
+
+      context "on ppc" do
+        let(:chef_run) do
+          ChefSpec::SoloRunner.new(platform: 'centos', version: '7.0') do |node|
+            node.automatic['kernel']['machine'] = 'ppc64'
+          end.converge(described_recipe)
+        end
+
+        it "installs fakeroot from source" do
+          expect(chef_run).to include_recipe("omnibus::_fakeroot_source")
+        end
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,8 +17,12 @@ RSpec.configure do |config|
 
     # Allow us to mimic a Windows node
     stub_const('File::ALT_SEPARATOR', '\\')
-    allow(ENV).to receive(:[])
-    allow(ENV).to receive(:[]).with('SYSTEMDRIVE').and_return('C:')
+    allow(ENV).to receive(:[]) do |name|
+      {
+        "PATH" => '',
+        "SYSTEMDRIVE" => "C:"
+      }[name]
+    end
   end
 
   config.log_level = :fatal


### PR DESCRIPTION
The CentOS builder will try and install fakeroot but fail if the EPEL repo is not configured.