### PR TITLE
[JEX-169] Use platform_version_compatibility_mode to install toolchain on ubuntu 16.04

### DIFF
--- a/recipes/_omnibus_toolchain.rb
+++ b/recipes/_omnibus_toolchain.rb
@@ -23,4 +23,5 @@ return unless omnibus_toolchain_enabled?
 chef_ingredient node['omnibus']['toolchain_name'] do
   version node['omnibus']['toolchain_version']
   channel :stable
+  platform_version_compatibility_mode true
 end


### PR DESCRIPTION
Use platform_version_compatibility_mode to get the toolchain package that was built and tested for the latest version of a supported platform if the specified version of that platform is not present in our official support matrix.

cc @chef-cookbooks/engineering-services 