### PR TITLE
Add fakeroot back to only debian style

### DIFF
--- a/recipes/_packaging.rb
+++ b/recipes/_packaging.rb
@@ -29,6 +29,7 @@ if debian?
   package 'dpkg-dev'
   package 'ncurses-dev'
   package 'zlib1g-dev'
+  package 'fakeroot'
 elsif freebsd?
   package 'devel/ncurses'
 elsif rhel?


### PR DESCRIPTION
@chef-cookbooks/engineering-services 
@chef-cookbooks/omnibus-maintainers 

Tested on debian and ubuntu
