### PR TITLE
Update toolchain version

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,7 +20,7 @@ default['omnibus'].tap do |omnibus|
   omnibus['build_user_home']    = nil
   omnibus['install_dir']        = nil
   omnibus['toolchain_name']     = 'omnibus-toolchain'
-  omnibus['toolchain_version']  = '1.1.9'
+  omnibus['toolchain_version']  = '1.1.10'
   omnibus['git_version']        = '2.6.2'
   omnibus['ruby_version']       = '2.1.8'
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,7 +20,7 @@ default['omnibus'].tap do |omnibus|
   omnibus['build_user_home']    = nil
   omnibus['install_dir']        = nil
   omnibus['toolchain_name']     = 'omnibus-toolchain'
-  omnibus['toolchain_version']  = '1.1.10'
+  omnibus['toolchain_version']  = '1.1.11'
   omnibus['git_version']        = '2.6.2'
   omnibus['ruby_version']       = '2.1.8'
 

--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -53,7 +53,7 @@ module Omnibus
 
     def build_user_shell
       if omnibus_toolchain_enabled?
-        "/opt/#{node['omnibus']['toolchain_name']}/embedded/bin/bash"
+        "/opt/#{node['omnibus']['toolchain_name']}/bin/bash"
       else
         '/usr/local/bin/bash'
       end

--- a/recipes/_environment.rb
+++ b/recipes/_environment.rb
@@ -167,7 +167,7 @@ if windows?
   end
 else
 
-  omnibus_env['PATH'] << "/opt/#{node['omnibus']['toolchain_name']}/embedded/bin" if omnibus_toolchain_enabled?
+  omnibus_env['PATH'] << "/opt/#{node['omnibus']['toolchain_name']}/bin" if omnibus_toolchain_enabled?
   omnibus_env['PATH'] << '/usr/local/bin'
 
   if aix?

--- a/recipes/_git.rb
+++ b/recipes/_git.rb
@@ -58,7 +58,7 @@ if omnibus_toolchain_enabled?
   # ca bundle that ships in the package. This can most likely be fixed by
   # a well placed `./configure` option when compiling git.
   #
-  execute "/opt/#{node['omnibus']['toolchain_name']}/embedded/bin/git config --global http.sslCAinfo /opt/#{node['omnibus']['toolchain_name']}/embedded/ssl/certs/cacert.pem" do
+  execute "/opt/#{node['omnibus']['toolchain_name']}/bin/git config --global http.sslCAinfo /opt/#{node['omnibus']['toolchain_name']}/embedded/ssl/certs/cacert.pem" do
     environment(
       'HOME' => build_user_home
     )

--- a/spec/recipes/git_spec.rb
+++ b/spec/recipes/git_spec.rb
@@ -18,7 +18,7 @@ describe 'omnibus::_git' do
     end
 
     it "properly configures git's cacert" do
-      expect(chef_run).to run_execute('/opt/omnibus-toolchain/embedded/bin/git config --global http.sslCAinfo /opt/omnibus-toolchain/embedded/ssl/certs/cacert.pem')
+      expect(chef_run).to run_execute('/opt/omnibus-toolchain/bin/git config --global http.sslCAinfo /opt/omnibus-toolchain/embedded/ssl/certs/cacert.pem')
         .with_user('omnibus')
     end
   end

--- a/spec/recipes/user_spec.rb
+++ b/spec/recipes/user_spec.rb
@@ -5,7 +5,7 @@ describe 'omnibus::_user' do
 
   it 'creates the omnibus build user' do
     expect(chef_run).to create_user('omnibus')
-      .with_shell(%r{(\/opt\/.*?\/embedded\/bin\/bash|\/usr\/local\/bin\/bash)})
+      .with_shell(%r{(\/opt\/.*?\/bin\/bash|\/usr\/local\/bin\/bash)})
   end
 
   it 'creates the home directory' do

--- a/test/fixtures/cookbooks/omnibus_build/recipes/execute.rb
+++ b/test/fixtures/cookbooks/omnibus_build/recipes/execute.rb
@@ -19,7 +19,7 @@ harmony_project_dir = File.join(build_user_home, 'harmony')
 # In order to have all the toolchain executables in the path, we need to set up
 # the environment like load-omnibus-toolchain.sh does. This is a little hacky
 # but we can't source the env like a shell does so this works.
-ENV['PATH'] = "/opt/omnibus-toolchain/embedded/bin:#{ENV['PATH']}"
+ENV['PATH'] = "/opt/omnibus-toolchain/bin:#{ENV['PATH']}"
 
 git harmony_project_dir do
   repository 'https://github.com/chef/omnibus-harmony.git'

--- a/test/fixtures/cookbooks/omnibus_build/recipes/execute.rb
+++ b/test/fixtures/cookbooks/omnibus_build/recipes/execute.rb
@@ -29,7 +29,7 @@ end
 
 omnibus_build 'harmony' do
   project_dir harmony_project_dir
-  log_level :internal
+  log_level :info
   config_overrides(
     append_timestamp: true
   )

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -4,7 +4,7 @@ describe 'On unix-ish', if: !windows? do
   describe 'platforms with omnibus toolchain enabled', if: omnibus_toolchain_enabled? do
     describe user(build_user) do
       it { should exist }
-      it { should have_login_shell '/opt/omnibus-toolchain/embedded/bin/bash' }
+      it { should have_login_shell '/opt/omnibus-toolchain/bin/bash' }
     end
 
     describe 'Xcode Command Line Tools', if: mac_os_x? do
@@ -22,26 +22,26 @@ describe 'On unix-ish', if: !windows? do
     end
 
     describe 'ruby' do
-      describe command('/opt/omnibus-toolchain/embedded/bin/ruby --version') do
+      describe command('/opt/omnibus-toolchain/bin/ruby --version') do
         its(:exit_status) { should eq 0 }
       end
     end
 
     describe 'bash --version' do
-      describe command('/opt/omnibus-toolchain/embedded/bin/bash --version') do
+      describe command('/opt/omnibus-toolchain/bin/bash --version') do
         its(:exit_status) { should eq 0 }
       end
     end
 
     describe 'git --version' do
-      describe command('/opt/omnibus-toolchain/embedded/bin/git --version') do
+      describe command('/opt/omnibus-toolchain/bin/git --version') do
         its(:exit_status) { should eq 0 }
       end
 
       # Ensure `https` remote functions correctly
       Dir.mktmpdir('omnibus') do |tmpdir|
         # Ensure HTTPS remote support works
-        describe command("/opt/omnibus-toolchain/embedded/bin/git clone https://github.com/chef-cookbooks/omnibus.git #{tmpdir}") do
+        describe command("/opt/omnibus-toolchain/bin/git clone https://github.com/chef-cookbooks/omnibus.git #{tmpdir}") do
           its(:exit_status) { should eq 0 }
         end
       end
@@ -51,10 +51,10 @@ describe 'On unix-ish', if: !windows? do
       it { should be_file }
 
       describe command("su - #{build_user} -l -c 'source ~/load-omnibus-toolchain.sh && which ruby'") do
-        its(:stdout) { should match %r{/opt/omnibus-toolchain/embedded/bin/ruby$} }
+        its(:stdout) { should match %r{/opt/omnibus-toolchain/bin/ruby$} }
       end
       describe command("su - #{build_user} -l -c 'source ~/load-omnibus-toolchain.sh && echo $PATH'") do
-        its(:stdout) { should match %r{^/opt/omnibus-toolchain/embedded/bin(.+)} }
+        its(:stdout) { should match %r{^/opt/omnibus-toolchain/bin(.+)} }
       end
     end
   end


### PR DESCRIPTION
This bumps the toolchain to version 1.1.10, which includes git/ruby version bumps and removes fakeroot.

@chef-cookbooks/omnibus-maintainers 
@chef-cookbooks/engineering-services 