### PR TITLE
Install fakeroot on RHEL

### DIFF
--- a/recipes/_packaging.rb
+++ b/recipes/_packaging.rb
@@ -36,6 +36,7 @@ elsif rhel?
   package 'ncurses-devel'
   package 'rpm-build'
   package 'zlib-devel'
+  package 'fakeroot'
 
   if node['platform_version'].satisfies?('>= 7')
     # EL 7 split rpm-sign into its own package:  http://cholla.mmto.org/computers/linux/rpm/signing.html


### PR DESCRIPTION
Since fakeroot is invoked during the rpm build, it should be installed.