### PR TITLE
Update omnibus-toolchain to version 1.1.42.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,7 +20,7 @@ default['omnibus'].tap do |omnibus|
   omnibus['build_user_home']    = nil
   omnibus['install_dir']        = nil
   omnibus['toolchain_name']     = 'omnibus-toolchain'
-  omnibus['toolchain_version']  = '1.1.39'
+  omnibus['toolchain_version']  = '1.1.42'
   omnibus['toolchain_channel']  = 'stable'
   omnibus['git_version']        = '2.6.2'
   omnibus['ruby_version']       = '2.1.8'


### PR DESCRIPTION
### Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

This is the first version that contains the full s390x matrix for both angry and regular toolchain.
@chef-cookbooks/engineering-services 

Signed-off-by: Scott Hain <shain@chef.io>