### PR TITLE
Windows has no build user group

### DIFF
--- a/recipes/_user.rb
+++ b/recipes/_user.rb
@@ -73,6 +73,7 @@ group node['omnibus']['build_user_group'] do
   members node['omnibus']['build_user']
   append true
   action :modify
+  ignore_failure true if windows? # Cannot modify a group that doesn't exist
 end
 
 # Ensure the build user's home directory exists
@@ -95,14 +96,14 @@ if windows?
   else
     directory build_user_home do
       owner node['omnibus']['build_user']
-      group node['omnibus']['build_user_group']
+      group node['omnibus']['build_user_group'] unless windows?
       action :create
     end
   end
 else
   directory build_user_home do
     owner node['omnibus']['build_user']
-    group node['omnibus']['build_user_group']
+    group node['omnibus']['build_user_group'] unless windows?
     mode '0755'
     action :create
   end


### PR DESCRIPTION
### Description

Avoids managing build user group on Windows.  Since the block that creates the group is set to `ignore_failure true`, there is no reason to try and operate on build group for Windows platform, since it will most likely fail to create the group on Windows.

Signed-off-by: Eric G. Wolfe <eric.wolfe@gmail.com>