### PR TITLE
add live_stream attribute to OmnibusBuild provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,10 @@ Attribute          | Default                                               | Des
 `log_level`        | `:internal`                                           | Log level used during the build. Valid values include: `:internal, :debug, :info, :warn, :error, :fatal`
 `config_file`      | `<PROJECT_DIR>/omnibus.rb`                            | Omnibus configuration file used for the build.
 `config_overrides` | `{}`                                                  | Overrides for one or more Omnibus config options
-`expire_cache`     | `false`                                               | Indiciates the Omnibus cache (including git cache) should be wiped before building.
+`expire_cache`     | `false`                                               | Indicates the Omnibus cache (including git cache) should be wiped before building.
 `build_user`       | `node['omnibus']['build_user']`                       | The user to execute the Omnibus build as.
 `environment`      | `{}`                                                  | Environment variables to set in the underlying build process.
+`live_stream`      | `false`                                               | Indicates output of build process should be logged to Chef event stream.
 
 #### Example Usage
 

--- a/libraries/omnibus_build.rb
+++ b/libraries/omnibus_build.rb
@@ -56,6 +56,9 @@ class Chef
     attribute :environment,
               kind_of: Hash,
               default: {}
+    attribute :live_stream,
+              kind_of: [TrueClass, FalseClass],
+              default: false
   end
 
   class Provider::OmnibusBuild < Provider::LWRPBase
@@ -139,6 +142,7 @@ class Chef
       )
       execute.cwd(new_resource.project_dir)
       execute.environment(environment)
+      execute.live_stream(new_resource.live_stream)
       execute.user(new_resource.build_user)
       execute.run_action(:run)
     end
@@ -172,6 +176,7 @@ class Chef
       execute.command("call #{windows_safe_path_join(build_user_home, 'load-omnibus-toolchain.bat')} && #{command}")
       execute.cwd(new_resource.project_dir)
       execute.environment(new_resource.environment)
+      execute.live_stream(new_resource.live_stream)
       execute.run_action(:run)
     end
   end

--- a/spec/libraries/provider_omnibus_build_spec.rb
+++ b/spec/libraries/provider_omnibus_build_spec.rb
@@ -25,6 +25,7 @@ describe Chef::Provider::OmnibusBuild do
   let(:project_dir) { '/tmp/harmony' }
   let(:config_overrides) { Hash.new }
   let(:expire_cache) { false }
+  let(:live_stream) { false }
   let(:environment) do
     {
       'FOO' => 'BAR',
@@ -40,6 +41,7 @@ describe Chef::Provider::OmnibusBuild do
     r.environment(environment)
     r.config_overrides(config_overrides)
     r.expire_cache(expire_cache)
+    r.live_stream(live_stream)
     r.build_user(build_user)
     r
   end
@@ -146,7 +148,8 @@ describe Chef::Provider::OmnibusBuild do
                                  environment: nil,
                                  run_action: nil,
                                  user: nil,
-                                 group: nil
+                                 group: nil,
+                                 live_stream: nil
       )
     end
 
@@ -177,6 +180,15 @@ describe Chef::Provider::OmnibusBuild do
     it 'executes the command as the provided user' do
       expect(execute_resource).to receive(:user).with(build_user)
       subject.send(:execute_with_omnibus_toolchain, command)
+    end
+
+    context 'live_stream is true' do
+      let(:live_stream) { true }
+
+      it 'executes the command with live_stream enabled' do
+        expect(execute_resource).to receive(:live_stream).with(live_stream)
+        subject.send(:execute_with_omnibus_toolchain, command)
+      end
     end
   end
 

--- a/spec/libraries/provider_omnibus_build_windows_spec.rb
+++ b/spec/libraries/provider_omnibus_build_windows_spec.rb
@@ -47,7 +47,8 @@ describe Chef::Provider::OmnibusBuildWindows do
                                  environment: nil,
                                  run_action: nil,
                                  user: nil,
-                                 group: nil
+                                 group: nil,
+                                 live_stream: nil
       )
     end
 


### PR DESCRIPTION
### Description

This change adds support for toggling the `live_stream` property of execute resources generated by `omnibus_build` resources.

### Issues Resolved

No existing issue for this feature.

Without this feature we were unable to use Omnibus to build Sensu via Travis, due to lack of output from the build. Enabling `live_stream` on our Omnibus build execution resources gives us enough live output that Travis allows our build to continue.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
