### PR TITLE
Make `windows_safe_path_join` helper safe on non-windows platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,12 @@ env:
     # Ignore warnings when running specs.
     - RUBYOPT="-W0"
   matrix:
-    - CHEF_VERSION=12.5.1 INSTANCE=default-debian-7
-    - CHEF_VERSION=12.5.1 INSTANCE=default-debian-8
-    - CHEF_VERSION=12.5.1 INSTANCE=default-ubuntu-1204
-    - CHEF_VERSION=12.5.1 INSTANCE=default-ubuntu-1404
-    - CHEF_VERSION=12.5.1 INSTANCE=default-centos-6
-    - CHEF_VERSION=12.5.1 INSTANCE=default-centos-7
+    - CHEF_VERSION=12.9.38 INSTANCE=default-debian-7
+    - CHEF_VERSION=12.9.38 INSTANCE=default-debian-8
+    - CHEF_VERSION=12.9.38 INSTANCE=default-ubuntu-1204
+    - CHEF_VERSION=12.9.38 INSTANCE=default-ubuntu-1404
+    - CHEF_VERSION=12.9.38 INSTANCE=default-centos-6
+    - CHEF_VERSION=12.9.38 INSTANCE=default-centos-7
     - CHEF_VERSION=current INSTANCE=default-debian-7
     - CHEF_VERSION=current INSTANCE=default-debian-8
     - CHEF_VERSION=current INSTANCE=default-ubuntu-1204

--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -20,8 +20,22 @@
 module Omnibus
   # Recipe Helpers
   module Helper
-    def windows_safe_path_join(*args)
-      ::File.join(args).gsub(::File::SEPARATOR, ::File::ALT_SEPARATOR || File::SEPARATOR)
+    #
+    # Convert the given path to be appropiate for shelling out on Windows.
+    #
+    # @param [String, Array<String>] pieces
+    #   the pieces of the path to join and fix
+    # @return [String]
+    #   the path with applied changes
+    #
+    def windows_safe_path_join(*pieces)
+      path = File.join(*pieces)
+
+      if File::ALT_SEPARATOR
+        path.gsub(File::SEPARATOR, File::ALT_SEPARATOR)
+      else
+        path
+      end
     end
 
     def windows_safe_path_expand(arg)


### PR DESCRIPTION
### Description

This PR the `windows_safe_path_join` helper method which would raise an exception when `File::ALT_SEPARATOR` returned `nil`

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>


/cc @chef-cookbooks/engineering-services 