### PR TITLE
Release v5.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@ omnibus Cookbook CHANGELOG
 ==========================
 This file is used to list changes made in each version of the omnibus cookbook.
 
+v5.1.1
+------
+- Make `windows_safe_path_join` smarter and allow strings or arrays as input.
+- Fix travis failures due to unsupported metadata.
+
 v5.1.0
 ------
 - Add `live_stream` attribute to `omnibus_build` resource

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'releng@chef.io'
 license           'Apache 2.0'
 description       'Prepares a machine to be an Omnibus builder.'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '5.1.0'
+version           '5.1.1'
 
 supports 'amazon'
 supports 'centos'


### PR DESCRIPTION
### Description

Prepare 5.1.1 release.

### Issues Resolved

- Make `windows_safe_path_join` smarter and allow strings or arrays as input.
- Fix travis failures due to unsupported metadata.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README or CHANGELOG if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

/cc @chef-cookbooks/omnibus-maintainers 
/cc @chef-cookbooks/engineering-services 