### PR TITLE
Switching to stable chefdk release since there is a bug in chef 12.18…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ dist: trusty
 addons:
   apt:
     sources:
-      - chef-current-trusty
+      - chef-stable-trusty
     packages:
       - chefdk
 
@@ -51,4 +51,4 @@ matrix:
       - /opt/chefdk/embedded/bin/foodcritic --version
     - script:
       - /opt/chefdk/bin/chef exec rake
-      env: UNIT_AND_LINT=1
+      env: CHEF_VERSION=12.17.44 UNIT_AND_LINT=1


### PR DESCRIPTION
… that is preventing tests

Signed-off-by: Scott Hain <shain@chef.io>

THIS PR SHOULD BE REVERTED AND SWITCHED BACK TO `current` once the bug in chef 12.18.x is fixed. (Will update with bug # later)