### PR TITLE
Use new `architecture` attribute on toolchain install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ dist: trusty
 addons:
   apt:
     sources:
-      - chef-stable-trusty
+      - chef-current-trusty
     packages:
       - chefdk
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -22,7 +22,7 @@ supports 'windows'
 
 depends 'build-essential', '>= 6.0.0'
 depends 'chef-sugar', '>= 3.2.0'
-depends 'chef-ingredient', '>= 0.18.0'
+depends 'chef-ingredient', '>= 0.21.4'
 depends 'git'
 depends 'homebrew'
 depends 'remote_install'

--- a/recipes/_omnibus_toolchain.rb
+++ b/recipes/_omnibus_toolchain.rb
@@ -17,44 +17,19 @@
 # limitations under the License.
 #
 
-if windows?
-  toolchain_options = {
-    product_name: node['omnibus']['toolchain_name'],
-    product_version: node['omnibus']['toolchain_version'],
-    channel: node['omnibus']['toolchain_channel'].to_sym,
-    # Override detected architecture on Windows as we use properly
-    # configured 64-bit instances to compile things in 32-bit mode.
-    architecture: (windows_arch_i386? ? 'i386' : 'x86_64'),
-  }
-
-  artifact_info = mixlib_install_artifact_info_for(toolchain_options)
-
-  remote_artifact_path = artifact_info.url
-  local_artifact_path  = ::File.join(Chef::Config[:file_cache_path], ::File.basename(remote_artifact_path))
-
-  remote_file local_artifact_path do
-    source remote_artifact_path
-    mode '0644'
-    checksum artifact_info.sha256
-    backup 1
-  end
-
-  omnibus_env['MSYSTEM'] << mingw_toolchain_name.upcase
-  omnibus_env['OMNIBUS_WINDOWS_ARCH'] << (windows_arch_i386? ? 'x86' : 'x64')
-  omnibus_env['BASH_ENV'] << windows_safe_path_join(toolchain_install_dir, 'embedded', 'bin', 'etc', 'msys2.bashrc')
-end
-
 chef_ingredient node['omnibus']['toolchain_name'] do
   version node['omnibus']['toolchain_version']
   channel node['omnibus']['toolchain_channel'].to_sym
+  architecture(windows_arch_i386? ? 'i386' : 'x86_64')
   platform_version_compatibility_mode true
-  if windows?
-    package_source local_artifact_path
-    action :install
-  else
-    action :upgrade
-  end
+  action(windows? ? :install : :upgrade)
 end
 
 omnibus_env['OMNIBUS_TOOLCHAIN_INSTALL_DIR'] << toolchain_install_dir
 omnibus_env['SSL_CERT_FILE'] << windows_safe_path_join(toolchain_install_dir, 'embedded', 'ssl', 'certs', 'cacert.pem')
+
+if windows?
+  omnibus_env['MSYSTEM'] << mingw_toolchain_name.upcase
+  omnibus_env['OMNIBUS_WINDOWS_ARCH'] << (windows_arch_i386? ? 'x86' : 'x64')
+  omnibus_env['BASH_ENV'] << windows_safe_path_join(toolchain_install_dir, 'embedded', 'bin', 'etc', 'msys2.bashrc')
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,15 @@ RSpec.configure do |config|
     stub_const('File::ALT_SEPARATOR', '\\')
     allow(ENV).to receive(:[])
     allow(ENV).to receive(:[]).with('SYSTEMDRIVE').and_return('C:')
+    # This stops "undefined method `split' for nil:NilClass" errors from
+    # being thrown by ChefSpec. This works around a Chef compatibility
+    # issue that was introduced in Chef 12.18+.
+    #
+    # See the following Chef issue for more details:
+    #
+    #   https://github.com/chef/chef/issues/5769
+    #
+    allow(ENV).to receive(:[]).with('PATH').and_return('')
   end
 
   config.log_level = :fatal


### PR DESCRIPTION
This change will require https://github.com/chef-cookbooks/chef-ingredient/pull/128 being merged and released and removal of 0ccc287.