### PR TITLE
Use Ohai to detect Linux architecture (i386/x86_64)

### DIFF
--- a/recipes/_omnibus_toolchain.rb
+++ b/recipes/_omnibus_toolchain.rb
@@ -20,7 +20,7 @@
 chef_ingredient node['omnibus']['toolchain_name'] do
   version node['omnibus']['toolchain_version']
   channel node['omnibus']['toolchain_channel'].to_sym
-  architecture(windows_arch_i386? ? 'i386' : 'x86_64')
+  architecture(windows_arch_i386? || node['kernel']['machine'] == 'i686' ? 'i386' : 'x86_64')
   platform_version_compatibility_mode true
   action(windows? ? :install : :upgrade)
 end


### PR DESCRIPTION
### Description

Uses Ohai to detect architecture flavor (i386/x86_64).

### Issues Resolved

Fixes #203 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

(bug fix/no new functionality)