### PR TITLE
Remove fancy_execute cookbook

### DIFF
--- a/.delivery/build-cookbook/metadata.rb
+++ b/.delivery/build-cookbook/metadata.rb
@@ -1,10 +1,9 @@
 name 'build-cookbook'
-maintainer 'The Authors'
-maintainer_email 'you@example.com'
-license 'all_rights'
+maintainer 'Chef Software, Inc.'
+maintainer_email 'releng@chef.io'
+license 'Apache-2.0'
 version '0.1.0'
 
 depends 'chef-sugar'
 depends 'delivery-truck'
 depends 'delivery-sugar'
-depends 'fancy_execute'

--- a/Berksfile
+++ b/Berksfile
@@ -8,7 +8,6 @@ metadata
 
 group :integration do
   cookbook 'apt'
-  cookbook 'fancy_execute'
   cookbook 'freebsd'
   cookbook 'yum-epel'
   fixture 'build'


### PR DESCRIPTION
Modern chef includes this functionality

Signed-off-by: Tim Smith <tsmith@chef.io>