### PR TITLE
Fix chef-ingredient issue and tweak windows SDK install

### DIFF
--- a/recipes/_omnibus_toolchain.rb
+++ b/recipes/_omnibus_toolchain.rb
@@ -39,6 +39,8 @@ if suse? && intel?
   end
 else
   chef_ingredient node['omnibus']['toolchain_name'] do
+    platform node['platform_family']
+    platform_version node['platform_version']
     version node['omnibus']['toolchain_version']
     channel node['omnibus']['toolchain_channel'].to_sym
     architecture arch

--- a/recipes/_packaging.rb
+++ b/recipes/_packaging.rb
@@ -57,7 +57,7 @@ elsif rhel?
   end
 elsif windows?
   include_recipe 'wix::default'
-  include_recipe 'windows-sdk::windows_sdk'
+  include_recipe 'windows-sdk::windows_sdk' unless ec2?
 
   omnibus_env['PATH'] << node['wix']['home']
   omnibus_env['PATH'] << node['seven_zip']['home']


### PR DESCRIPTION
Don't install windows SDK on ec2 nodes, as they have it in the base ami. Add platform family and version to chef-ingredient resource as both are required now when specifying arch

Signed-off-by: Scott Hain <shain@chef.io>

@chef-cookbooks/engineering-services 

### Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
