### PR TITLE
omnibus_build: Duplicate an immutable property

### DIFF
--- a/libraries/omnibus_build.rb
+++ b/libraries/omnibus_build.rb
@@ -148,7 +148,7 @@ class Chef
     end
 
     def environment
-      environment = new_resource.environment || {}
+      environment = new_resource.environment.dup || {}
       # Ensure we inheriet the calling procceses $PATH
       environment['PATH'] = ENV['PATH']
       # We need to all underlying build process respect the build user

--- a/spec/libraries/provider_omnibus_build_spec.rb
+++ b/spec/libraries/provider_omnibus_build_spec.rb
@@ -173,7 +173,7 @@ describe Chef::Provider::OmnibusBuild do
     end
 
     it 'executes the command with the provided environment' do
-      expect(execute_resource).to receive(:environment).with(environment)
+      expect(execute_resource).to receive(:environment).with(hash_including(environment))
       subject.send(:execute_with_omnibus_toolchain, command)
     end
 


### PR DESCRIPTION
### Description
In Chef Client 13 some types of resource properties became immutable, including Hash.
So, in order to change the "environment" hash, we need to create a mutable copy first.

### Issues Resolved

Fixes #213