### PR TITLE
Bump omnibus toolchain version. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,10 @@ addons:
   apt:
     sources:
       - chef-current-trusty
-    packages:
-      - chefdk
+
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -y chefdk=1.5.0-1
 
 # Don't `bundle install` which takes about 1.5 mins
 install: echo "skip bundle install"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,7 +20,7 @@ default['omnibus'].tap do |omnibus|
   omnibus['build_user_home']    = nil
   omnibus['install_dir']        = nil
   omnibus['toolchain_name']     = 'omnibus-toolchain'
-  omnibus['toolchain_version']  = '1.1.64'
+  omnibus['toolchain_version']  = '1.1.72'
   omnibus['toolchain_channel']  = 'stable'
   omnibus['git_version']        = '2.6.2'
   omnibus['ruby_version']       = '2.1.8'

--- a/spec/libraries/provider_omnibus_build_spec.rb
+++ b/spec/libraries/provider_omnibus_build_spec.rb
@@ -23,7 +23,7 @@ describe Chef::Provider::OmnibusBuild do
   let(:build_user) { 'some_user' }
   let(:build_user_home) { "/home/#{build_user}" }
   let(:project_dir) { '/tmp/harmony' }
-  let(:config_overrides) { Hash.new }
+  let(:config_overrides) {}
   let(:expire_cache) { false }
   let(:live_stream) { false }
   let(:environment) do


### PR DESCRIPTION
This pulls in the latest GCC for windows which is required as the previous toolchain had a GCC version that had some bugs that were preventing chefdk from building

Signed-off-by: Scott Hain <shain@chef.io>

### Description

@chef-cookbooks/engineering-services @chef-cookbooks/omnibus-maintainers 

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
