### PR TITLE
Add packages needed for Debian (deb) packages signing.

### DIFF
--- a/recipes/_packaging.rb
+++ b/recipes/_packaging.rb
@@ -30,6 +30,8 @@ if debian?
   package 'ncurses-dev'
   package 'zlib1g-dev'
   package 'fakeroot'
+  package 'binutils'
+  package 'gnupg'
 elsif freebsd?
   package 'devel/ncurses'
 elsif rhel?

--- a/spec/recipes/packaging_spec.rb
+++ b/spec/recipes/packaging_spec.rb
@@ -14,6 +14,9 @@ describe 'omnibus::_packaging' do
       expect(chef_run).to install_package('dpkg-dev')
       expect(chef_run).to install_package('ncurses-dev')
       expect(chef_run).to install_package('zlib1g-dev')
+      expect(chef_run).to install_package('fakeroot')
+      expect(chef_run).to install_package('binutils')
+      expect(chef_run).to install_package('gnupg')
     end
   end
 


### PR DESCRIPTION
### Description

This commit adds two new packages to be installed on Debian (and its derivatives e.g. Ubuntu) which are needed by Omnibus to sign the newly built packages. The newly added packages are `binutils` (to supply the GNU `ar` binary) and `gnupg` to ensure that GnuPG is installed.

### Issues Resolved

https://github.com/chef/omnibus/issues/402

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

Signed-off-by: Krzysztof Wilczynski <kw@linux.com>