### PR TITLE
Update Windows SDK installation method.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -29,7 +29,6 @@ depends 'remote_install'
 depends 'seven_zip'
 depends 'windows'
 depends 'wix'
-depends 'windows-sdk'
 
 gem 'pkg-config'
 


### PR DESCRIPTION
This is due to what appears to be a bug in the actual sdk setup executable.
When installing from a dos path (anything that has > 8 characters in the name),
the installer will truncate the download URL for some unknown reason, turning
<base_url>/Patches/<name> into <base_url>/hes/<name>. I have no idea what is
causing this but this code essentially forces a powershell invocation in the
current directory, which by default uses the correct "Long File" format.

Signed-off-by: Scott Hain <shain@chef.io>

### Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
