### PR TITLE
Fix AIX env PATH

### DIFF
--- a/recipes/_environment.rb
+++ b/recipes/_environment.rb
@@ -177,7 +177,8 @@ else
   omnibus_env['PATH'] << '/usr/local/bin'
 
   if aix?
-    omnibus_env['PATH'].unshift('/opt/IBM/xlC/13.1.3/bin:/opt/IBM/xlc/13.1.3/bin:/opt/freeware/bin')
+    omnibus_env['PATH'] << '/opt/freeware/bin'
+    omnibus_env['PATH'].unshift('/opt/IBM/xlC/13.1.3/bin:/opt/IBM/xlc/13.1.3/bin:/opt/IBM/xlC/13.1.0/bin:/opt/IBM/xlc/13.1.0/bin')
   elsif solaris_10?
     omnibus_env['PATH'] << '/usr/sfw/bin'
     omnibus_env['PATH'] << '/usr/ccs/bin'


### PR DESCRIPTION
freeware should be searched last else compile fails

Signed-off-by: Jaymala Sinha <jsinha@chef.io>

### Description

Update AIX PATH to include updated compiler and search freeware last

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
