### PR TITLE
undo a change from previous cookstyle, and cookstyle

### DIFF
--- a/libraries/omnibus_build.rb
+++ b/libraries/omnibus_build.rb
@@ -130,7 +130,7 @@ class Chef
       execute = Resource::Execute.new("#{new_resource.project_name}: #{command}", run_context)
       execute.command(
         <<-CODE.gsub(/^ {10}/, '')
-          . #{::File.join(build_user_home('load-omnibus-toolchain.sh'))}
+          . #{::File.join(build_user_home, 'load-omnibus-toolchain.sh')}
           #{command}
         CODE
       )

--- a/recipes/_compile.rb
+++ b/recipes/_compile.rb
@@ -47,7 +47,7 @@ elsif mac_os_x?
   # Use homebrew as the default package manager on macOS. We cannot install homebrew
   # until AFTER we have installed the XCode command line tools via build-essential
   # node.set['homebrew']['owner']       = node['omnibus']['build_user']
-  node.normal['homebrew']['auto-update'] = false
+  node.default['homebrew']['auto-update'] = false
   include_recipe 'homebrew::default'
 
   # Ensure /usr/local/* are writable by the `staff` group


### PR DESCRIPTION
### Description

In commit ca4e42910a77c, the arguments to `File.join` were changed
from two arguments using the return from `build_user_home` and the
`load-omnnibus-toolchain.sh` file to using the return from
`build_user_home` sending an argument `load-omnibus-toolchain.sh`.
This causes an ArgumentError exception to be raised when attempting to
use the `omnibus_build` resource in an existing cookbook because
`build_user_home`'s method signature takes no arguments.

It's unclear whether the cookstyle of January 2019 caused an error on
this particular line of code, but I ran cookstyle 5.20.0 from Chef
Workstation 0.16.5 (latest stable release as of today) against this
change and it was not a finding. It did find an issue with the use of
`node.normal` in the `_compile.rb` recipe, so I fixed that unrelated
file in this change.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>