### PR TITLE
Update ChefSpec tests to test on FreeBSD 11 and not 11.1

### DIFF
--- a/spec/recipes/compile_spec.rb
+++ b/spec/recipes/compile_spec.rb
@@ -32,7 +32,7 @@ describe 'omnibus::_compile' do
 
   context 'on freebsd' do
     let(:chef_run) do
-      ChefSpec::SoloRunner.new(platform: 'freebsd', version: '11.1')
+      ChefSpec::SoloRunner.new(platform: 'freebsd', version: '11')
                           .converge(described_recipe)
     end
 

--- a/spec/recipes/packaging_spec.rb
+++ b/spec/recipes/packaging_spec.rb
@@ -16,7 +16,7 @@ describe 'omnibus::_packaging' do
 
   context 'on freebsd' do
     let(:chef_run) do
-      ChefSpec::SoloRunner.new(platform: 'freebsd', version: '11.1')
+      ChefSpec::SoloRunner.new(platform: 'freebsd', version: '11')
                           .converge(described_recipe)
     end
 


### PR DESCRIPTION
11.1 is deprecated data

Signed-off-by: Tim Smith <tsmith@chef.io>